### PR TITLE
Merge job filtering, crude contract creation.

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -8,16 +8,17 @@ specifies that any unauthenticated user can "create", "read", "update",
 and "delete" any "Todo" records.
 =========================================================================*/
 const schema = a.schema({
-  RequiredMaterials: a.enum(["PLA", "NYLON"]),
+  RequiredMaterials: a.enum(["Plastic", "Resin", "CarbonFiber"]),
+  Colors: a.enum(["Red", "White", "Black", "Blue", "Transparent"]),
   Job: a
     .model({
       submitter: a.string().required(),
       title: a.string(),
       description: a.string(),
       amountOffered: a.float(),
-      requiredMaterials: a.ref("RequiredMaterials"),
+      requiredMaterials: a.ref("RequiredMaterials").array(),
+      colors: a.ref("Colors").array(),
       contract: a.hasOne('Contract', 'jobID')
-
     })
     .authorization((allow) => [allow.ownerDefinedIn("submitter")]),
   Contract: a

--- a/src/components/JobsTable.tsx
+++ b/src/components/JobsTable.tsx
@@ -1,0 +1,128 @@
+import { generateClient } from 'aws-amplify/data';
+import { useAuthenticator } from '@aws-amplify/ui-react';
+import type { Schema } from '../../amplify/data/resource';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { Pagination } from '@aws-amplify/ui-react';
+import { Link } from 'react-router-dom';
+import {
+    FormControlLabel,
+    TextField,
+    Box,
+    Button,
+    Checkbox,
+    styled,
+    Divider,
+    IconButton,
+    Table,
+    TableContainer,
+    TableBody,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableFooter,
+    TablePagination,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { format } from 'date-fns';
+
+type Job = Schema['Job']['type'];
+
+function formatDate(date_str: string): string {
+    return format(new Date(date_str), 'MM/dd/yy hh:mm aa');
+}
+
+export default function JobsTable(props) {
+    const filters = props.filters;
+    const allowDelete = props.allowDelete ?? false;
+    const allowEdit = props.allowEdit ?? false;
+    const client = generateClient<Schema>();
+    const { user, signOut } = useAuthenticator((context) => [context.user]);
+    const [jobs, setJobs] = useState([]);
+    const [pageTokens, setPageTokens] = useState([]);
+    const [currentPageIndex, setCurrentPageIndex] = useState(1);
+    const [hasMorePages, setHasMorePages] = useState(true);
+
+    const fetchData = async (init, nextPage) => {
+        if (init || (hasMorePages && currentPageIndex === pageTokens.length)) {
+            const { data: new_jobs, nextToken } = await client.models.Job.list({
+                filter: filters,
+                limit: 30,
+                nextToken: pageTokens[pageTokens.length - 1],
+                authMode: 'userPool'
+            });
+
+            if (!nextToken) {
+                setHasMorePages(false);
+            }
+            setPageTokens(init ? [nextToken] : [...pageTokens, nextToken]);
+            if (init) {
+                setJobs(new_jobs.length > 0 ? [new_jobs] : []);
+            } else if (new_jobs.length > 0) {
+                setJobs([...jobs, new_jobs]);
+            }
+        }
+
+        if (nextPage) {
+            setCurrentPageIndex((pi) => pi + 1);
+        }
+    }
+
+    useEffect(() => { fetchData(true, false); }, [props.filters]);
+
+    if (jobs.length === 0) {
+        return (<p>No jobs matching criteria.</p>);
+    }
+
+    return (
+        <>
+            <TableContainer>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>Title</TableCell>
+                            <TableCell>Time Created</TableCell>
+                            <TableCell>Amount Offered ($)</TableCell>
+                            <TableCell>Description</TableCell>
+                            {props.allowEdit ? <TableCell></TableCell> : null}
+                            {props.allowDelete ? <TableCell></TableCell> : null}
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {jobs[currentPageIndex - 1].map((job) => {
+                            return (
+                                <TableRow key={job['id']}>
+                                    <TableCell>{job['title']}</TableCell>
+                                    <TableCell>{formatDate(job['createdAt'])}</TableCell>
+                                    <TableCell>{job['amountOffered']}</TableCell>
+                                    <TableCell>{job['description']}</TableCell>
+                                    {props.allowEdit ?
+                                        (<TableCell>
+                                            <Link to={`/home/editJob/${job['id']}`}>
+                                                <FontAwesomeIcon icon={faEdit} />
+                                            </Link>
+                                        </TableCell>) : null
+                                    }
+                                    {props.allowDelete ?
+                                        (<TableCell>
+                                            <Link to={`/home/deleteJob/${job['id']}`}>
+                                                <FontAwesomeIcon icon={faTrash} />
+                                            </Link>
+                                        </TableCell>) : null
+                                    }
+                                </TableRow>);
+                        })}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+            <Pagination
+                currentPage={currentPageIndex}
+                totalPages={pageTokens.length}
+                hasMorePages={hasMorePages}
+                onPrevious={() => setCurrentPageIndex(currentPageIndex - 1)}
+                onNext={() => fetchData(false, true)}
+                onChange={(pageIndex) => setCurrentPageIndex(pageIndex)}
+            />
+        </>
+    );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,56 +16,10 @@ import {
 } from '@mui/material';
 
 import '../styles/homeStyle.css'
+import JobsTable from '../components/JobsTable.tsx';
 import { useEffect, useState } from 'react';
-import { format } from 'date-fns';
 
 type Job = Schema['Job']['type'];
-
-function formatDate(date_str: string): string {
-    return format(new Date(date_str), 'MM/dd/yy hh:mm aa');
-}
-
-function JobsList(props: { jobs: Job[] }) {
-    const jobs = props['jobs'];
-
-    return (
-        <TableContainer>
-            <Table>
-                <TableHead>
-                    <TableRow>
-                        <TableCell>Title</TableCell>
-                        <TableCell>Time Created</TableCell>
-                        <TableCell>Amount Offered ($)</TableCell>
-                        <TableCell>Description</TableCell>
-                        <TableCell></TableCell>
-                        <TableCell></TableCell>
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    {jobs.map((job) => {
-                        return (
-                            <TableRow key={job['id']}>
-                                <TableCell>{job['title']}</TableCell>
-                                <TableCell>{formatDate(job['createdAt'])}</TableCell>
-                                <TableCell>{job['amountOffered']}</TableCell>
-                                <TableCell>{job['description']}</TableCell>
-                                <TableCell>
-                                    <Link to={`/home/editJob/${job['id']}`}>
-                                        <FontAwesomeIcon icon={faEdit} />
-                                    </Link>
-                                </TableCell>
-                                <TableCell>
-                                    <Link to={`/home/deleteJob/${job['id']}`}>
-                                        <FontAwesomeIcon icon={faTrash} />
-                                    </Link>
-                                </TableCell>
-                            </TableRow>);
-                    })}
-                </TableBody>
-            </Table>
-        </TableContainer>
-    );
-}
 
 export function EditJob() {
     const params = useParams();
@@ -185,60 +139,17 @@ export function DeleteJob(props) {
 }
 
 export default function () {
-    const client = generateClient<Schema>();
     const { user, signOut } = useAuthenticator((context) => [context.user]);
-    const [userJobs, setUserJobs] = useState<Job[][]>([]);
-    const [pageTokens, setPageTokens] = useState([]);
-    const [currentPageIndex, setCurrentPageIndex] = useState(1);
-    const [hasMorePages, setHasMorePages] = useState(true);
+    const userJobsFilter = { submitter: { eq: user.userId } };
+    const userContractJobsFilter = { 'contract.contractor': { eq: user.userId } };
 
-    const fetchData = async (init, nextPage) => {
-        if (init || (hasMorePages && currentPageIndex === pageTokens.length)) {
-            const { data: jobs, nextToken } = await client.models.Job.list({
-                filter: {
-                    submitter: {
-                        'eq': user.userId
-                    }
-                },
-                limit: 5,
-                nextToken: pageTokens[pageTokens.length - 1],
-                authMode: 'userPool'
-            });
-
-            if (!nextToken) {
-                setHasMorePages(false);
-            }
-            setPageTokens([...pageTokens, nextToken]);
-            setUserJobs([...userJobs, jobs]);
-            console.log([...userJobs, jobs]);
-            console.log("NEW JOBS");
-            console.log(jobs);
-
-        }
-
-        if (nextPage) {
-            setCurrentPageIndex((pi) => pi + 1);
-        }
-
-    }
-
-    useEffect(() => { fetchData(true, false) }, []);
-
-    if (userJobs.length === 0) {
-        return (<p>No jobs yet.</p>);
-    }
 
     return (
         <>
-            <JobsList jobs={userJobs[currentPageIndex - 1]} />
-            <Pagination
-                currentPage={currentPageIndex}
-                totalPages={pageTokens.length}
-                hasMorePages={hasMorePages}
-                onPrevious={() => setCurrentPageIndex(currentPageIndex - 1)}
-                onNext={() => fetchData(false, true)}
-                onChange={(pageIndex) => setCurrentPageIndex(pageIndex)}
-            />
+        <h3>Jobs Posted by You</h3>
+        <JobsTable filters={userJobsFilter} allowEdit={true} allowDelete={true}/>
+        <h3>Jobs Accepted By You</h3>
+        <JobsTable filters={userContractJobsFilter}/>
         </>
     )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -143,11 +143,31 @@ export default function () {
     const userJobsFilter = { submitter: { eq: user.userId } };
     const userContractJobsFilter = { 'contract.contractor': { eq: user.userId } };
 
+    const rowSelectPopup = (job_id) => {
+        return (
+        <>
+        <Button>
+        <Link to={`/home/deleteJob/${job_id}`}>
+            <FontAwesomeIcon icon={faTrash} />
+            <span>Delete job</span>
+        </Link>
+        </Button>
+        <Button>
+        <Link to={`/home/editJob/${job_id}`}>
+            <FontAwesomeIcon icon={faEdit} />
+            <span>Edit job</span>
+        </Link>
+        </Button>
+        </>)
+    }
 
     return (
         <>
         <h3>Jobs Posted by You</h3>
-        <JobsTable filters={userJobsFilter} allowEdit={true} allowDelete={true}/>
+        <JobsTable filters={userJobsFilter} 
+            selectPopup={rowSelectPopup}
+            allowEdit={true} 
+            allowDelete={true}/>
         <h3>Jobs Accepted By You</h3>
         <JobsTable filters={userContractJobsFilter}/>
         </>

--- a/src/pages/Market.tsx
+++ b/src/pages/Market.tsx
@@ -272,7 +272,7 @@ export default function Market({ user }: { user: AuthUser }) {
         'materials': {
             'Plastic': false,
             'Resin': false,
-            'Carbon Fiber': false
+            'CarbonFiber': false
         },
         'colors': {
             'Red': false,
@@ -295,7 +295,6 @@ export default function Market({ user }: { user: AuthUser }) {
 
         let colors = [];
         let color, val;
-        console.log(formData.colors);
         for([color, val] of Object.entries(formData.colors)) {
             if(val) {
                 colors.push(color);
@@ -323,10 +322,28 @@ export default function Market({ user }: { user: AuthUser }) {
         let {data: jobs, errors} = await client.models.Job.list({
             filter: new_filter
         });
-        console.log("Callback JOBS");
-        console.log(jobs);
-        console.log("Callback filters");
-        console.log(new_filter.materials);
+    }
+
+    const acceptJobAsContract = async (job_id) => {
+        let resp = await client.models.Contract.create({
+            jobID: job_id,
+            contractor: user.userId
+        });
+
+        if('errors' in resp) {
+            console.log("FAILED");
+            // do sth about it.
+        }
+
+        let {data: contracts, errs}= await client.models.Contract.list();
+        console.log("CONTRACTS");
+        console.log(contracts);
+    }
+
+    const rowSelectPopup = (job_id) => {
+        return (
+        <Button onClick={() => acceptJobAsContract(job_id)}>Accept job as contract</Button>
+        );
     }
 
     return (
@@ -343,10 +360,12 @@ export default function Market({ user }: { user: AuthUser }) {
                 <div className='jobs-list'>
                     <h2>Jobs List</h2>
                     <Divider></Divider>
+                    <Box>
                     {Object.keys(filters).length > 0 ?
-                        (<JobsTable filters={filters}/>) :
+                        (<JobsTable filters={filters} selectPopup={rowSelectPopup}/>) :
                         (<p>Apply some filters, and we'll show available jobs</p>)
                     }
+                    </Box>
                 </div>
             </div>
             {showPopUp &&

--- a/src/styles/marketStyle.css
+++ b/src/styles/marketStyle.css
@@ -11,7 +11,6 @@
   padding: 10px 10px 20px 10px;
   margin-top: 20px;
   width: 175px;
-  height: 480px;
   margin-left: 10px;
   border: 1px solid rgb(161, 161, 161);
   display: flex;
@@ -57,7 +56,6 @@
 .filters {
   display: flex;
   flex-direction: column;
-  height: 50px;
   overflow-y: auto;
   border-radius: 5px;
   border: 1px solid rgb(192, 192, 192);


### PR DESCRIPTION
Branch implements job filtering and a very crude contract accepting functionality to the pat branch. A couple notes.
(1) Right now, filtering with multiple select is performed through direct equivalence. I.e. If I query for a job with colors "red" and "white, it will return only jobs with colors red and white, but not jobs with only red or only white. The fix to this probably involves writing resource.ts, probably to make a distinct model for color-job relationships. Same with materials. Also, we should probably specify that you can only have one contract per user.
(2) We should find some way to collapse the job creation, job edit, and job search components into a single class. They all end up filling out the same handful of input elements. 
(3) I haven't bothered to make jobs accepted as contracts disappear from the JobsTable. This is a to-do for later. Also, I have not implemented any restrictions on users accepting their own jobs as contracts.
(4 [***]) I didn't figure out how to search for only jobs without contracts, another todo for later.